### PR TITLE
add server ci/cd

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -14,7 +14,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
-  RUSTFLAGS: -D warnings
 
 jobs:
   format:
@@ -48,7 +47,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: apps/server
-      - run: |
+      - name: Run Clippy
+        run: |
           cargo clippy --all-targets --all-features -- \
             -D warnings \
             -D clippy::todo \
@@ -83,4 +83,7 @@ jobs:
         - uses: Swatinem/rust-cache@v2
           with:
             workspaces: apps/server
-        - run: cargo build --release --all-features
+        - name: Build
+          env:
+            RUSTFLAGS: -D warnings
+          run: cargo build --release --all-features


### PR DESCRIPTION
adds CI/CD that will run for the backend. Strict linting rules. Runs a format check, clippy with some extra lints disallowing `todo!`, unwraps, and some other things. It also tries to build the app and runs all tests.